### PR TITLE
Add magic effect exclusion support

### DIFF
--- a/src/Acheron/Hooks/Hooks.cpp
+++ b/src/Acheron/Hooks/Hooks.cpp
@@ -265,7 +265,7 @@ namespace Acheron
 			return none;
 		}()) {
 		case healing:
-			if (Defeat::IsDefeated(target))
+			if (Defeat::IsDefeated(target) && Validation::AllowRescueEffect(base))
 				Defeat::RescueActor(target, true);
 			break;
 		case damaging:
@@ -320,7 +320,7 @@ namespace Acheron
 
 			for (auto& e : spell->effects) {
 				auto base = e ? e->baseEffect : nullptr;
-				if (base && base->data.flags.all(RE::EffectSetting::EffectSettingData::Flag::kDetrimental)) {
+				if (base && base->data.flags.all(RE::EffectSetting::EffectSettingData::Flag::kDetrimental) && !Validation::AllowDetrimentalEffect(base)){
 					return false;
 				}
 			}

--- a/src/Acheron/Validation.cpp
+++ b/src/Acheron/Validation.cpp
@@ -86,6 +86,7 @@ namespace Acheron
 					const auto root{ YAML::LoadFile(filepath) };
 					parseList(root["LocationA"], exclLocAll);
 					parseList(root["LocationT"], exclLocTp);
+					parseList(root["MagicEffect"], exclMagicEffect);
 
 					readBranch(root["Assailant"], VTarget::Assailant);
 					readBranch(root["Victim"], VTarget::Victim);
@@ -159,6 +160,16 @@ namespace Acheron
 		if (!CheckVictimID(a_victim->formID))
 			return false;
 		return CheckExclusion(VTarget::Victim, a_victim);
+	}
+
+	bool Validation::AllowRescueEffect(RE::EffectSetting* a_effect)
+	{
+		return !std::ranges::contains(exclMagicEffect, a_effect->GetFormID());
+	}
+
+	bool Validation::AllowDetrimentalEffect(RE::EffectSetting* a_effect)
+	{
+		return std::ranges::contains(exclMagicEffect, a_effect->GetFormID());
 	}
 
 	bool Validation::AllowTeleport()

--- a/src/Acheron/Validation.h
+++ b/src/Acheron/Validation.h
@@ -26,6 +26,16 @@ namespace Acheron
 		/// @return if victim may be defeated by aggressor
 		_NODISCARD static bool ValidatePair(RE::Actor* a_victim, RE::Actor* a_aggressor);
 
+		/// @brief Validate whether an effect may be used rescue an actor
+		/// @param a_effect The base effect being applied
+		/// @return if the affect may be used to rescue an actor
+		_NODISCARD static bool AllowRescueEffect(RE::EffectSetting* a_effect);
+
+		/// @brief Validate whether a detrimental affect may be applied to a defeated actor
+		/// @param a_effect The base effect being applied
+		/// @return if the affect may be applied to a defeated actor
+		_NODISCARD static bool AllowDetrimentalEffect(RE::EffectSetting* a_effect);
+
 		/// @brief Ensure that the player can be teleported away from their current location
 		/// @return if teleporting the player is permitted
 		_NODISCARD static bool AllowTeleport();
@@ -39,6 +49,7 @@ namespace Acheron
 
 		static inline std::vector<RE::FormID> exclLocAll{};									// Always disabled locations
 		static inline std::vector<RE::FormID> exclLocTp{};									// Teleport only disabled locations
+		static inline std::vector<RE::FormID> exclMagicEffect{};				// Excluded Magic Effects
 		static inline std::vector<RE::FormID> exclNPC[VTarget::Total];			// Excluded Actor Bases
 		static inline std::vector<RE::FormID> exclRef[VTarget::Total];			// Excluded object refs
 		static inline std::vector<RE::FormID> exclRace[VTarget::Total];			// Excluded races


### PR DESCRIPTION
Occasionally it is desirable/necessary for a spell to be applied to an actor while an Event is ongoing. However, if this spell contains any Detrimental flagged effects it is blocked entirely, or if it contains a healing effect then the actor will be rescued prematurely.

This PR adds magic effect exclusion support so that Acheron can be told to ignore specific effects that either should not trigger a rescue, or should be allowed to apply even though they are "detrimental".

A single `MagicEffect` list is added to the custom validation file to cover both cases.