### PR TITLE
Fix mcm when events share a quest; NUL bytes in logs

### DIFF
--- a/src/Acheron/Resolution.cpp
+++ b/src/Acheron/Resolution.cpp
@@ -448,8 +448,10 @@ namespace Acheron
 		const auto where = a_name.rfind(';');
 		const auto idstr = a_name.substr(where + 1);
 		const auto id = static_cast<RE::FormID>(std::stoul(idstr));
+		const auto namestart = a_name.find(']') + 2;
+		const auto namelen = a_name.find(';') - namestart;
 		for (auto&& e : Events[a_type]) {
-			if (e.quest->formID == id) {
+			if ((e.quest->formID == id) && (a_name.compare(namestart, namelen, e.name) == 0)) {
 				e.weight = a_weight;
 				return MakeMCMEventKey(e);
 			}

--- a/src/Acheron/Validation.cpp
+++ b/src/Acheron/Validation.cpp
@@ -403,7 +403,7 @@ namespace Acheron
 			return false;
 		}
 		const auto race = a_actor->GetRace();
-		if (race && find(a_actor->GetFormID(), exclRace)) {
+		if (race && find(race->GetFormID(), exclRace)) {
 			return false;
 		}
 		// visitor returns true on the first iteration that returns true, false otherwise

--- a/src/Serialization/Serialize.cpp
+++ b/src/Serialization/Serialize.cpp
@@ -91,8 +91,8 @@ namespace Serialization
 		std::string ret{};
 		ret.resize(size);
 		const char* it = reinterpret_cast<char*>(&a_type);
-		for (size_t i = 0, j = size - 2; i < size - 1; i++, j--)
-			ret[j] = it[i];
+		for (size_t i = 0, j = size - 1; i < size; i++, j--)
+			ret[j] = std::isprint(it[i]) ? it[i] : '_';
 
 		return ret;
 	}


### PR DESCRIPTION
The recent mcm event tab changes cause problems for consequences that share an implementing quest while providing multiple entries with different conditions. This adds the event name back into the lookup as an additional check once quest id's are confirmed to match.

Also fixed an issue with NUL bytes showing up in logs.