### PR TITLE
Fix compatibility with Archery Locational Damage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ else()
 endif()
 
 # ---- Dependencies ----
+add_compile_definitions(SKSE_SUPPORT_XBYAK)
 if(BUILD_SKYRIMVR)
     add_compile_definitions(SKYRIMVR)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)

--- a/src/Acheron/Hooks/Hooks.cpp
+++ b/src/Acheron/Hooks/Hooks.cpp
@@ -241,7 +241,7 @@ namespace Acheron
 			const auto aggressor = aggressorPtr.get();
 			const float hp = a_target->GetActorValue(RE::ActorValue::kHealth);
 			auto dmg = a_hitData.totalDamage + fabs(GetIncomingEffectDamage(a_target));
-			AdjustByDifficultyMult(dmg, aggressor->IsPlayerRef());
+			AdjustByDifficultyMult(dmg, a_target->IsPlayerRef());
 			bool negate;
 			switch (GetProcessType(aggressor, hp <= dmg)) {
 			case ProcessType::Lethal:
@@ -318,7 +318,7 @@ namespace Acheron
 				const float health = target->GetActorValue(RE::ActorValue::kHealth);
 				float dmg = base->data.secondaryAV == RE::ActorValue::kHealth ? effect.magnitude * base->data.secondAVWeight : effect.magnitude;
 				dmg += GetIncomingEffectDamage(target);	 // + GetTaperDamage(effect.magnitude, data->data);
-				AdjustByDifficultyMult(dmg, caster && caster->IsPlayerRef());
+				AdjustByDifficultyMult(dmg, target->IsPlayerRef());
 				bool negate;
 				switch (GetProcessType(caster.actor, health <= fabs(dmg) + 2)) {
 				case ProcessType::Lethal:
@@ -378,7 +378,7 @@ namespace Acheron
 
 		const float hp = a_actor->GetActorValue(RE::ActorValue::kHealth);
 		auto effectdmg = fabs(GetIncomingEffectDamage(a_actor));
-		AdjustByDifficultyMult(effectdmg, false);
+		AdjustByDifficultyMult(effectdmg, a_actor->IsPlayerRef());
 		if (a_explosion.damage + effectdmg < hp) {
 			return ret;
 		}
@@ -519,7 +519,7 @@ namespace Acheron
 		if (s->GetType() != RE::Setting::Type::kSignedInteger)
 			return;
 
-		std::string diff{ "fDiffMultHP"s + (playerPOV ? "ByPC"s : "ToPC"s) };
+		std::string diff{ "fDiffMultHP"s + (playerPOV ? "ToPC"s : "ByPC"s) };
 		switch (s->GetSInt()) {
 		case 0:
 			diff.append("VE");

--- a/src/Acheron/Hooks/Hooks.cpp
+++ b/src/Acheron/Hooks/Hooks.cpp
@@ -59,9 +59,6 @@ namespace Acheron
 		REL::Relocation<std::uintptr_t> mha{ RELID(33742, 34526), OFFSET(0x1E8, 0x20B) };
 		_DoesMagicHitApply = trampoline.write_call<5>(mha.address(), DoesMagicHitApply);
 		// ==================================================
-		REL::Relocation<std::uintptr_t> explH{ RELID(42677, 43849), OFFSET(0x38C, 0x3C2) };
-		_ExplosionHit = trampoline.write_call<5>(explH.address(), ExplosionHit);
-		// ==================================================
 		REL::Relocation<std::uintptr_t> det{ RELID(41659, 42742), OFFSET(0x526, 0x67B) };
 		_DoDetect = trampoline.write_call<5>(det.address(), DoDetect);
 		// ==================================================
@@ -369,27 +366,6 @@ namespace Acheron
 			}
 		}
 		return _DoesMagicHitApply(a_target, a_data);
-	}
-
-	// return false if hit should not be processed
-	bool Hooks::ExplosionHit(RE::Explosion& a_explosion, float* a_flt, RE::Actor* a_actor)
-	{
-		auto ret = _ExplosionHit(a_explosion, a_flt, a_actor);
-		if (!ret || !a_actor || !Validation::CanProcessDamage() || !IsNPC(a_actor) || a_actor->IsCommandedActor())
-			return ret;
-		if (Defeat::IsDamageImmune(a_actor) || !Validation::ValidatePair(a_actor, nullptr))
-			return false;
-
-		const float hp = a_actor->GetActorValue(RE::ActorValue::kHealth);
-		auto effectdmg = fabs(GetIncomingEffectDamage(a_actor));
-		AdjustByDifficultyMult(effectdmg, a_actor->IsPlayerRef());
-		if (a_explosion.damage + effectdmg < hp) {
-			return ret;
-		}
-		auto owner = a_explosion.GetActorOwner();
-		auto ref = owner ? owner->AsReference() : nullptr;
-		auto aggressor = Processing::AggressorInfo(ref ? ref->As<RE::Actor>() : nullptr, a_actor);
-		return Processing::RegisterDefeat(a_actor, aggressor) ? false : ret;
 	}
 
 	float Hooks::FallAndPhysicsDamage(RE::Actor* a_this, float a_fallDistance, float a_defaultMult)

--- a/src/Acheron/Hooks/Hooks.h
+++ b/src/Acheron/Hooks/Hooks.h
@@ -40,7 +40,6 @@ namespace Acheron
 		static void UpdateCharacter(RE::Character* a_this, float a_delta);
 		static void MagicHit(uint64_t* unk1, RE::ActiveEffect& effect, uint64_t* unk3, uint64_t* unk4, uint64_t* unk5);
 		static bool DoesMagicHitApply(RE::MagicTarget* a_target, RE::MagicTarget::AddTargetData* a_data);
-		static bool ExplosionHit(RE::Explosion& explosion, float* flt, RE::Actor* actor);
 		static float FallAndPhysicsDamage(RE::Actor* a_this, float a_fallDistance, float a_defaultMult);
 		static uint8_t* DoDetect(RE::Actor* viewer, RE::Actor* target, int32_t& detectval, uint8_t& unk04, uint8_t& unk05, uint32_t& unk06, RE::NiPoint3& pos, float& unk08, float& unk09, float& unk10);
 		static bool GetActivateText(RE::TESNPC* a_this, RE::TESObjectREFR* a_activator, RE::BSString& a_dst);
@@ -64,7 +63,6 @@ namespace Acheron
 		static inline REL::Relocation<decltype(UpdateCharacter)> _UpdateCharacter;
 		static inline REL::Relocation<decltype(MagicHit)> _MagicHit;
 		static inline REL::Relocation<decltype(DoesMagicHitApply)> _DoesMagicHitApply;
-		static inline REL::Relocation<decltype(ExplosionHit)> _ExplosionHit;
 		static inline REL::Relocation<decltype(DoDetect)> _DoDetect;
 		static inline REL::Relocation<decltype(FallAndPhysicsDamage)> _FallAndPhysicsDamage;
 		static inline REL::Relocation<decltype(GetActivateText)> _GetActivateText;

--- a/src/Acheron/Hooks/Hooks.h
+++ b/src/Acheron/Hooks/Hooks.h
@@ -27,13 +27,17 @@ namespace Acheron
 			None,
 		};
 
+		enum class HitResult {
+			Prevent = 0,
+			Allow = 1,
+		};
+
 		// Hooks
 		static void CompileAndRun(RE::Script* a_script, RE::ScriptCompiler* a_compiler, RE::COMPILER_NAME a_name, RE::TESObjectREFR* a_targetRef);
 		static void UpdatePlayer(RE::PlayerCharacter* player, float delta);
 		static RE::NiAVObject* Load3D(RE::Character& a_this, bool a_arg1);
 		static void UpdateCombat(RE::Character* a_this);
 		static void UpdateCharacter(RE::Character* a_this, float a_delta);
-		static void WeaponHit(RE::Actor* a_target, RE::HitData& a_hitData);
 		static void MagicHit(uint64_t* unk1, RE::ActiveEffect& effect, uint64_t* unk3, uint64_t* unk4, uint64_t* unk5);
 		static bool DoesMagicHitApply(RE::MagicTarget* a_target, RE::MagicTarget::AddTargetData* a_data);
 		static bool ExplosionHit(RE::Explosion& explosion, float* flt, RE::Actor* actor);
@@ -42,6 +46,7 @@ namespace Acheron
 		static bool GetActivateText(RE::TESNPC* a_this, RE::TESObjectREFR* a_activator, RE::BSString& a_dst);
 
 		// Hit Processing
+		static HitResult ProcessHitData(RE::Actor* a_target, RE::HitData& a_hitData);
 		static ProcessType GetProcessType(RE::Actor* a_aggressor, bool a_lethal);
 		static bool HandleLethal(RE::Actor* a_victim, RE::Actor* a_aggressor);
 		static bool HandleExposed(RE::Actor* a_victim);
@@ -57,7 +62,6 @@ namespace Acheron
 		static inline REL::Relocation<decltype(Load3D)> _Load3D;
 		static inline REL::Relocation<decltype(UpdateCombat)> _UpdateCombat;
 		static inline REL::Relocation<decltype(UpdateCharacter)> _UpdateCharacter;
-		static inline REL::Relocation<decltype(WeaponHit)> _WeaponHit;
 		static inline REL::Relocation<decltype(MagicHit)> _MagicHit;
 		static inline REL::Relocation<decltype(DoesMagicHitApply)> _DoesMagicHitApply;
 		static inline REL::Relocation<decltype(ExplosionHit)> _ExplosionHit;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,7 +9,8 @@
     "simpleini",
     "magic-enum",
     "yaml-cpp",
-    "nlohmann-json"
+    "nlohmann-json",
+    "xbyak"
   ],
   "overrides": [
     {


### PR DESCRIPTION
This fixes compatibility with Archery Locational Damage (and any other mod that manipulates HitData damage values).

Do do so, we move the previous WeaponHit hook logic from a from a single call location to the interior of the called function. This ensures we 1. catch the call location hooked by ALD and 2. always see the values after ALDs modification.

This also catches additional damage sources. Notably Traps (bear trap, swinging axes, etc...) which were previously unhandled, and Explosions for which the existing hook catches false positives as it sees damage before falloff/resistances are applied.

Also found and fixed in testing the difficulty multiplier logic was subtly incorrect (ToPC/ByPC is dependent on target rather than aggressor)