### PR TITLE
Fix crash rescuing actor after load

### DIFF
--- a/src/Acheron/Defeat.cpp
+++ b/src/Acheron/Defeat.cpp
@@ -110,9 +110,12 @@ namespace Acheron
 			{
 			case VictimState::Defeating:
 				logger::info("{:X} ({}) is still being defeated, delaying rescue", a_victim->GetFormID(), a_victim->GetDisplayFullName());
-				SKSE::GetTaskInterface()->AddTask([&]() {
-					RescueActor(a_victim, undo_pacify);
-				});
+				{
+					auto victim = a_victim->GetHandle();
+					SKSE::GetTaskInterface()->AddTask([victim, undo_pacify]() {
+						RescueActor(victim.get().get(), undo_pacify);
+					});
+				}
 				return;
 			case VictimState::Rescuing:
 				logger::error("{:X} ({}) is already being rescued", a_victim->GetFormID(), a_victim->GetDisplayFullName());
@@ -168,10 +171,11 @@ namespace Acheron
 	{
 		RescueActor(a_victim, false);
 		if (a_undo_pacify) {
-			std::thread([a_victim]() {
+			auto victim = a_victim->GetHandle();
+			std::thread([victim]() {
 				std::this_thread::sleep_for(4s);
 				SKSE::GetTaskInterface()->AddTask([=]() {
-					UndoPacify(a_victim);
+					UndoPacify(victim.get().get());
 				});
 			}).detach();
 		}

--- a/src/Acheron/Defeat.cpp
+++ b/src/Acheron/Defeat.cpp
@@ -369,7 +369,9 @@ namespace Acheron
 						ref->As<RE::BGSKeywordForm>()->AddKeyword(GameForms::Defeated);
 					}
 
-					Victims.emplace(formID, std::make_shared<VictimData>(time));
+					auto data = std::make_shared<VictimData>(time);
+					data->state.store(VictimState::Defeated);
+					Victims.emplace(formID, data);
 				}
 				logger::info("Loaded {} Victims from cosave", Victims.size());
 			}

--- a/src/Papyrus/Functions.cpp
+++ b/src/Papyrus/Functions.cpp
@@ -14,8 +14,9 @@ namespace Papyrus
 			a_vm->TraceStack("Cannot Defeat a none Actor", a_stackID);
 			return;
 		}
+		auto actor = a_actor->GetHandle();
 		SKSE::GetTaskInterface()->AddTask([=]() {
-			Acheron::Defeat::DefeatActor(a_actor);
+			Acheron::Defeat::DefeatActor(actor.get().get());
 		});
 	}
 
@@ -25,8 +26,9 @@ namespace Papyrus
 			a_vm->TraceStack("Cannot Rescue a none Actor", a_stackID);
 			return;
 		}
+		auto actor = a_actor->GetHandle();
 		SKSE::GetTaskInterface()->AddTask([=]() {
-			Acheron::Defeat::RescueActor(a_actor, undopacify);
+			Acheron::Defeat::RescueActor(actor.get().get(), undopacify);
 		});
 	}
 


### PR DESCRIPTION
Incorrect VictimState after load resulted in endless "still being defeated, delaying rescue".
Actor pointer became invalid during delay resulting in crash.